### PR TITLE
Add the `search.index_all_pages` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ stall_threshold = 200
 | `input_placeholder` | String | `i18n "search"` | The placeholder of search input.
 | `paginate` | Integer | `20` | How many results per page, at least `20`, for making sure the load more event will be able to trigger.
 | `max_results` | Integer | `100` | Denotes the max number of returned search results.
+| `index_all_pages` | Boolean | `true` | When `true`, all pages except `noindex` pages will be indexed, include non-regular pages, such as home and taxonomy lists.
 
 ## CSS Variables
 

--- a/config.toml
+++ b/config.toml
@@ -35,3 +35,4 @@ path = "github.com/razonyang/hugo-mod-icons/vendors/bootstrap"
 # shortcut_search = ["Control", "k"]
 # input_placeholder = "Type to search"
 # paginate = 20
+# index_all_pages = true

--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -16,3 +16,7 @@ languageName = "简体中文"
 
 [languages.zh-hant]
 languageName = "繁体中文"
+
+[params.search]
+input_placeholder = 'Type to search'
+# index_all_pages = false

--- a/exampleSite/config/_default/params.en.toml
+++ b/exampleSite/config/_default/params.en.toml
@@ -1,2 +1,0 @@
-[search]
-input_placeholder = 'Type to search'

--- a/exampleSite/config/_default/params.zh-hans.toml
+++ b/exampleSite/config/_default/params.zh-hans.toml
@@ -1,2 +1,0 @@
-[search]
-input_placeholder = '请输入关键词'

--- a/exampleSite/config/_default/params.zh-hant.toml
+++ b/exampleSite/config/_default/params.zh-hant.toml
@@ -1,2 +1,0 @@
-[search]
-input_placeholder = '請輸入關鍵詞'

--- a/layouts/partials/search/assets/js-resource.html
+++ b/layouts/partials/search/assets/js-resource.html
@@ -1,14 +1,18 @@
 {{- $js := resources.Get "search/js/index.ts" }}
 {{/* The SVG icons. */}}
 {{- $icons := dict
-  "home" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "house" "width" "1.5rem" "height" "1.5rem"))
-  "section" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "list" "width" "1.5rem" "height" "1.5rem"))
   "page" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "file-earmark-richtext" "width" "1.5rem" "height" "1.5rem"))
-  "term" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "tag" "width" "1.5rem" "height" "1.5rem"))
-  "taxonomy" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "tags" "width" "1.5rem" "height" "1.5rem"))
   "heading" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "hash" "width" "1.5rem" "height" "1.5rem"))
   "meta" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "info-circle" "width" "1.5rem" "height" "1.5rem"))
 }}
+{{- if default true .Site.Params.search.index_all_pages }}
+  {{- $icons = merge $icons (dict
+    "home" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "house" "width" "1.5rem" "height" "1.5rem"))
+    "section" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "list" "width" "1.5rem" "height" "1.5rem"))
+    "term" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "tag" "width" "1.5rem" "height" "1.5rem"))
+    "taxonomy" (partial "icons/icon" (dict "vendor" "bootstrap" "name" "tags" "width" "1.5rem" "height" "1.5rem")))
+  }}
+{{- end }}
 {{/* Index files URL. */}}
 {{- $indices := slice }}
 {{- range .Sites }}

--- a/layouts/partials/search/index.json.html
+++ b/layouts/partials/search/index.json.html
@@ -1,5 +1,6 @@
 {{- $items := slice }}
-{{- $pages := .Site.Pages }}
+{{- $indexAllPages := default true .Site.Params.search.index_all_pages }}
+{{- $pages := cond $indexAllPages .Site.Pages .Site.RegularPages }}
 {{- $pages = where $pages "Params.noindex" "ne" true }}
 {{- range $pages }}
   {{- $page := . }}


### PR DESCRIPTION
When `false` only regular pages will be indexed.

Fixed #45 